### PR TITLE
fix: add `types` field to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
       "types": "./dist/esm/index.d.ts"
     }
   },
+  "types": "./dist/esm/index.d.ts",
   "scripts": {
     "test": "vitest",
     "test:ci": "vitest run",


### PR DESCRIPTION
fixes #66

docs: https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package