### PR TITLE
Add icloud.com to more.ts

### DIFF
--- a/src/domains/more.ts
+++ b/src/domains/more.ts
@@ -11,6 +11,7 @@ export const more: DomainList = [
   "games.com",
   "goowy.com",
   "gte.net",
+  "icloud.com",
   "love.com",
   "netscape.net",
   "rocketmail.com",


### PR DESCRIPTION
Adds icloud.com to more.ts since it is a fairly popular email domain