### PR TITLE
Add mail.de domain

### DIFF
--- a/packages/email-misspelled/src/domains/more.ts
+++ b/packages/email-misspelled/src/domains/more.ts
@@ -25,5 +25,6 @@ export const more: DomainList = [
   "y7mail.com",
   "ybb.ne.jp",
   "ygm.com",
-  "ymail.com"
+  "ymail.com",
+  "mail.de"
 ]


### PR DESCRIPTION
This pull request adds a new email domain to the `more` domain list in `packages/email-misspelled/src/domains/more.ts`.

Domain list update:

* Added `"mail.de"` to the `more` domain list to improve coverage of recognized email domains.


Should fix: https://github.com/julien-amblard/email-misspelled/issues/88